### PR TITLE
games-strategy/openra-20171014: fix typo

### DIFF
--- a/games-strategy/openra/openra-20171014.ebuild
+++ b/games-strategy/openra/openra-20171014.ebuild
@@ -108,12 +108,12 @@ pkg_preinst() {
 
 pkg_postinst() {
 	gnome2_icon_cache_update
-	fdo-xdg_desktop_database_update
+	xdg_desktop_database_update
 	xdg_mimeinfo_database_update
 }
 
 pkg_postrm() {
 	gnome2_icon_cache_update
-	fdo-xdg_desktop_database_update
+	xdg_desktop_database_update
 	xdg_mimeinfo_database_update
 }


### PR DESCRIPTION
@cerebrum fdo- is typo in eclass description.